### PR TITLE
Introduce Python type stubs for the bindings

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7,10 +7,42 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+tests_no_zope = ["cloudpickle", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+tests = ["cloudpickle", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+docs = ["sphinx-notfound-page", "zope.interface", "sphinx", "furo"]
+dev = ["cloudpickle", "pre-commit", "sphinx-notfound-page", "sphinx", "furo", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+
+[[package]]
+name = "black"
+version = "22.8.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
@@ -44,6 +76,32 @@ zig = ["ziglang (>=0.9.0,<0.10.0)"]
 patchelf = ["patchelf"]
 
 [[package]]
+name = "mypy"
+version = "0.981"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -55,6 +113,26 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
+name = "pathspec"
+version = "0.10.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.5.2"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
+test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+
+[[package]]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
@@ -63,8 +141,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
@@ -113,15 +191,25 @@ category = "main"
 optional = false
 python-versions = ">=3.7"
 
+[[package]]
+name = "typing-extensions"
+version = "4.3.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "de89a46ba46325b20b9706ce749736b38613b62c2fd2110cef869ee7ba004270"
+content-hash = "2cd6647333886edfd1443aac067c8cfb5870004a2b3aabbf08abd9e7cea6e2a9"
 
 [metadata.files]
-attrs = [
-    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
-    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+attrs = []
+black = []
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
@@ -131,22 +219,21 @@ iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
-maturin = [
-    {file = "maturin-0.13.5-py3-none-linux_armv6l.whl", hash = "sha256:dcfe029fcff0e5d9d47907b7162b4f219706655ff82992e9dc90df51f7ff95d7"},
-    {file = "maturin-0.13.5-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:b8a3f26530a112158a13c539b88708196103cbd6bf318c16bccb39cd51f8e8f2"},
-    {file = "maturin-0.13.5-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:bfde627753667421c376834e53a485569495e34f5028742b36fc37bfa75713bf"},
-    {file = "maturin-0.13.5-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:d5314d2376ab252944d08f08641cf4aeecb125f3ace0d0fcb4a464e733765210"},
-    {file = "maturin-0.13.5-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:4c1ac521bb58af48ad30351576f4ad59205277b503f56b211c992711fd26a673"},
-    {file = "maturin-0.13.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:3fa3ad9df626bcba8fff0017a44f91021e5419786fc3402f66a82b88e99578e4"},
-    {file = "maturin-0.13.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:a7a7efae2a973d0cf4b00d44aa810df8135f73931e053412142557432f8bb292"},
-    {file = "maturin-0.13.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:9f9f14cd7ad67dbf327b21a46f884b7f1b1843fee2a5f7d153b7014025c24a9c"},
-    {file = "maturin-0.13.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e12084c7fe39ef821c7d46ce46f307ac53ff4324a00c53ccf4485bba3bfb3c38"},
-    {file = "maturin-0.13.5-py3-none-win32.whl", hash = "sha256:39b9e82584a0b8dc7f5709785db5f7924b906e8820e577147ca15b3a44d07316"},
-    {file = "maturin-0.13.5-py3-none-win_amd64.whl", hash = "sha256:17f51aaa5f026e0ffa9f83424811fadbbedcd0f5ec971480759e27cc978d931e"},
-    {file = "maturin-0.13.5-py3-none-win_arm64.whl", hash = "sha256:639470baa67d65c2f7dc6ce012cb5ef6c8b6d5ff512995c359dc83769070be6d"},
-    {file = "maturin-0.13.5.tar.gz", hash = "sha256:491618f77de70697269ec62d4e166c6ec6b3669d2326a1dad43a49a531f2fe7f"},
+maturin = []
+mypy = []
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
-packaging = []
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pathspec = []
+platformdirs = [
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
@@ -159,8 +246,12 @@ pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
-pytest = [
-    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
-    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
+pytest = []
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-tomli = []
+typing-extensions = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ maturin = "^0.13.5"
 pytest = "^7.1.3"
 
 [tool.poetry.dev-dependencies]
+black = "^22.8.0"
+mypy = "^0.981"
 
 [build-system]
 requires = ["maturin>=0.13,<0.14"]

--- a/pyrevm.pyi
+++ b/pyrevm.pyi
@@ -1,0 +1,84 @@
+from typing import Optional, Type
+
+class CfgEnv:
+    def __new__(cls: Type["CfgEnv"]) -> "CfgEnv": ...
+
+class BlockEnv:
+    def __new__(
+        cls: Type["BlockEnv"],
+        number: Optional[int] = None,
+        coinbase: Optional[str] = None,
+        timestamp: Optional[int] = None,
+        difficulty: Optional[int] = None,
+        basefee: Optional[int] = None,
+        gas_limit: Optional[int] = None,
+    ) -> "BlockEnv": ...
+
+class TxEnv:
+    def __new__(
+        cls: Type["TxEnv"],
+        caller: Optional[str] = None,
+        gas_limit: Optional[int] = None,
+        gas_price: Optional[int] = None,
+        gas_priority_fee: Optional[int] = None,
+        to: Optional[str] = None,
+        value: Optional[int] = None,
+        data: Optional[list[int]] = None,
+        chain_id: Optional[int] = None,
+        nonce: Optional[int] = None,
+    ) -> "TxEnv": ...
+
+class Env:
+    def __new__(
+        cls: Type["Env"],
+        cfg: Optional[CfgEnv] = None,
+        block: Optional[BlockEnv] = None,
+        tx: Optional[TxEnv] = None,
+    ) -> "Env": ...
+
+class AccountInfo:
+    @property
+    def balance(self: "AccountInfo") -> int: ...
+    @property
+    def nonce(self: "AccountInfo") -> int: ...
+    @property
+    def code(self: "AccountInfo") -> list[int]: ...
+    @property
+    def code_hash(self: "AccountInfo") -> list[int]: ...
+    def __new__(
+        cls: Type["AccountInfo"],
+        nonce: int,
+        code_hash: Optional[bytes] = None,
+        code: Optional[bytes] = None,
+    ) -> "AccountInfo": ...
+
+class EvmOpts:
+    env: Env
+    fork_url: Optional[str]
+    fork_block_number: Optional[int]
+    gas_limit: int
+    tracing: bool
+    def __new__(
+        cls: Type["EvmOpts"],
+        env: Optional[Env],
+        fork_url: Optional[str],
+    ) -> "EvmOpts": ...
+
+class EVM:
+    def __new__(
+        cls: Type["EVM"],
+        env: Optional[Env] = None,
+        fork_url: Optional[str] = None,
+        fork_block_number: Optional[int] = None,
+        gas_limit: int = 18446744073709551615,
+        tracing: bool = False,
+    ) -> "EVM": ...
+    def basic(self: "EVM", address: str) -> Optional[AccountInfo]: ...
+    def insert_account_info(self: "EVM", address: str, info: AccountInfo) -> None: ...
+    def call_raw_committing(
+        self: "EVM",
+        caller: str,
+        to: str,
+        value: Optional[int] = None,
+        data: Optional[list[int]] = None,
+    ) -> None: ...

--- a/pytest/test.py
+++ b/pytest/test.py
@@ -2,34 +2,36 @@ import pytest
 
 from pyrevm import *
 
-address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" # vitalik.eth
+address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"  # vitalik.eth
 address2 = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
 fork_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27"
+
 
 def test_revm():
     # set up an evm
     evm = EVM(
         # can fork from a remote node
-        fork_url=fork_url, 
+        fork_url=fork_url,
         # can set tracing to true/false
-        tracing = True, 
+        tracing=True,
         # can configure the environment
-        env = Env(
-            block = BlockEnv( timestamp = 100
-        ))
-    );
+        env=Env(block=BlockEnv(timestamp=100)),
+    )
 
     vb_before = evm.basic(address)
     assert vb_before != 0
 
     # Execute the tx
     evm.call_raw_committing(
-        caller = address,
-        to = address2,
-        value = 10000
+        caller=address,
+        to=address2,
+        value=10000
         # data
-    );
+    )
 
+    info = evm.basic(address2)
+
+    assert info is not None
     assert vb_before != evm.basic(address)
-    assert evm.basic(address2).balance == 10000
+    assert info.balance == 10000


### PR DESCRIPTION
I wish PyO3 had automatic type stub generation but alas, not _quite_ yet: https://github.com/PyO3/pyo3/issues/2454

This PR introduces some manually-written types. Gonna need to keep types manually up to date if the underlying Rust changes, though, which might be annoying.

Maturin should automatically pick up the type bindings at build time: https://maturin.rs/project_layout.html#adding-python-type-information